### PR TITLE
lazy load default kaffy field value

### DIFF
--- a/lib/kaffy/resource_schema.ex
+++ b/lib/kaffy/resource_schema.ex
@@ -157,7 +157,6 @@ defmodule Kaffy.ResourceSchema do
   end
 
   def kaffy_field_value(conn, schema, {field, options}) do
-    default_value = kaffy_field_value(schema, field)
     ft = Kaffy.ResourceSchema.field_type(schema.__struct__, field)
     value = Map.get(options || %{}, :value)
 
@@ -184,7 +183,7 @@ defmodule Kaffy.ResourceSchema do
         value
 
       true ->
-        default_value
+        kaffy_field_value(schema, field)
     end
   end
 

--- a/test/kaffy_test.exs
+++ b/test/kaffy_test.exs
@@ -1,7 +1,7 @@
 defmodule KaffyTest do
   use ExUnit.Case
   doctest Kaffy
-  alias KaffyTest.Schemas.{Person, Pet}
+  alias KaffyTest.Schemas.{Company, Person, Pet}
   # alias KaffyTest.Admin.PersonAdmin
 
   test "greets the world" do
@@ -56,9 +56,16 @@ defmodule KaffyTest do
       assert "Abdullah" == ResourceSchema.kaffy_field_value(nil, person, field)
     end
 
+    test "kaffy_field_value/3 should handle preloaded structs with a custom function" do
+      person = %Person{company: %Company{name: "Dashbit"}}
+
+      options = {:company, %{name: "Company", value: fn p -> p.company.name end}}
+      assert "Dashbit" == ResourceSchema.kaffy_field_value(%{}, person, options)
+    end
+
     test "associations/1 must return all associations for the schema" do
       associations = ResourceSchema.associations(Person)
-      assert [:pets] == associations
+      assert [:pets, :company] == associations
       pet_assoc = ResourceSchema.associations(Pet)
       assert [:person] == pet_assoc
     end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -10,6 +10,7 @@ defmodule KaffyTest.Schemas.Person do
     field(:birth_date, :date)
     field(:address, :string)
     has_many(:pets, KaffyTest.Schemas.Pet)
+    belongs_to(:company, KaffyTest.Schemas.Company)
   end
 end
 
@@ -30,5 +31,14 @@ defmodule KaffyTest.Schemas.Pet do
     field(:type, :string, default: "feline")
     field(:weight, :decimal)
     belongs_to(:person, KaffyTest.Schemas.Person)
+  end
+end
+
+defmodule KaffyTest.Schemas.Company do
+  use Ecto.Schema
+
+  schema "companies" do
+    field(:name, :string)
+    has_many(:people, KaffyTest.Schemas.Person)
   end
 end


### PR DESCRIPTION
This introduces a minor performance boost (removes unnecessary JSON encoding in most of the cases). 
However most importantly this is a quick fix to allow writing custom index queries like this:

```
  def custom_index_query(_conn, _schema, query) do
    from(r in query, join: c in Company, select: %{r | company: c})
  end
```

or

```
  def custom_index_query(_conn, _schema, query) do
    from(r in query, preload: :company)
  end
```

(right now it fails because the default value tries to be calculated and Jason cannot by default encode regular Ecto schemas).

One might ask why do we need these queries. In the `index` function you might want to do something like this:

```
  def index(_) do
    [
      id: nil,
      company: %{
        name: "Company",
        value: fn request ->
          request = Api.Repo.preload(request, :company)
          request.company.name
        end
      },
      inserted_at: nil
    ]
  end
```

However this introduces N+1 problem. Not a big deal I guess, but why not just not introduce it.

At this moment there is a solution, we can write the custom index query like this (but it's less optimal imo as it doesn't set a proper schema but just a pure map on a field that is expected to be a map):

```
  def custom_index_query(_conn, _schema, query) do
    from(r in query, join: c in Company, select: %{r | company: %{name: c.name}})
  end
```