### PR TITLE
Fix changeset errors

### DIFF
--- a/lib/kaffy/resource_callbacks.ex
+++ b/lib/kaffy/resource_callbacks.ex
@@ -62,6 +62,9 @@ defmodule Kaffy.ResourceCallbacks do
       {:error, :not_found} ->
         Kaffy.Utils.repo().update(changeset)
 
+      {:error, error} ->
+        {:error, error}
+
       unexpected_error ->
         {:error, unexpected_error}
     end

--- a/lib/kaffy/resource_callbacks.ex
+++ b/lib/kaffy/resource_callbacks.ex
@@ -30,6 +30,9 @@ defmodule Kaffy.ResourceCallbacks do
       {:error, :not_found} ->
         Kaffy.Utils.repo().insert(changeset)
 
+      {:error, error} ->
+        {:error, error}
+
       unexpected_error ->
         {:error, unexpected_error}
     end
@@ -167,6 +170,9 @@ defmodule Kaffy.ResourceCallbacks do
     else
       {:error, :not_found} ->
         Kaffy.Utils.repo().delete(changeset)
+
+      {:error, error} ->
+        {:error, error}
 
       unexpected_error ->
         {:error, unexpected_error}

--- a/lib/kaffy/resource_form.ex
+++ b/lib/kaffy/resource_form.ex
@@ -124,7 +124,7 @@ defmodule Kaffy.ResourceForm do
         text_input(form, field, opts)
 
       :richtext ->
-        opts = Keyword.put(opts, :class, "kaffy-editor")
+        opts = add_class(opts, "kaffy-editor")
         textarea(form, field, opts)
 
       :textarea ->
@@ -140,8 +140,8 @@ defmodule Kaffy.ResourceForm do
         text_input(form, field, opts)
 
       t when t in [:boolean, :boolean_checkbox] ->
-        checkbox_opts = Keyword.put(opts, :class, "custom-control-input")
-        label_opts = Keyword.put(opts, :class, "custom-control-label")
+        checkbox_opts = add_class(opts, "custom-control-input")
+        label_opts = add_class(opts, "custom-control-label")
 
         [
           {:safe, ~s(<div class="custom-control custom-checkbox">)},
@@ -151,8 +151,8 @@ defmodule Kaffy.ResourceForm do
         ]
 
       :boolean_switch ->
-        checkbox_opts = Keyword.put(opts, :class, "custom-control-input")
-        label_opts = Keyword.put(opts, :class, "custom-control-label")
+        checkbox_opts = add_class(opts, "custom-control-input")
+        label_opts = add_class(opts, "custom-control-label")
 
         [
           {:safe, ~s(<div class="custom-control custom-switch">)},
@@ -246,8 +246,8 @@ defmodule Kaffy.ResourceForm do
   end
 
   defp flatpickr_generic(form, field, opts, placeholder, fp_class, icon \\ "📅") do
-    opts = Keyword.put(opts, :class, "flatpickr-input")
-    opts = Keyword.put(opts, :class, "form-control")
+    opts = add_class(opts, "flatpickr-input")
+    opts = add_class(opts, "form-control")
     opts = Keyword.put(opts, :id, "inlineFormInputGroup")
     opts = Keyword.put(opts, :placeholder, placeholder)
     opts = Keyword.put(opts, :"data-input", "")
@@ -422,5 +422,9 @@ defmodule Kaffy.ResourceForm do
           [label_tag, field_tag, field_feeback]
         end
     end
+  end
+
+  defp add_class(opts, class) do
+    Keyword.update(opts, :class, class, &"#{&1} #{class}")
   end
 end

--- a/priv/static/assets/scss/style.css
+++ b/priv/static/assets/scss/style.css
@@ -4758,7 +4758,6 @@ textarea.form-control {
 }
 
 .invalid-feedback {
-  display: none;
   width: 100%;
   margin-top: 0.25rem;
   font-size: 80%;


### PR DESCRIPTION
This fixes error handling properly in Kaffy:

<img width="1356" alt="image" src="https://user-images.githubusercontent.com/6031161/224651809-2138af4d-c830-4121-90f9-013c3f7c43b4.png">

There are two changes. First of all we had issue that this was not working and throwing like this: https://linear.app/walnut/issue/CCS-466/caseclauseerror-no-case-clause-matching-error-error

Second after I fixed this I noticed the errors are not displayed in details so this was the second part of the fix.